### PR TITLE
Fix sometimes skips words

### DIFF
--- a/src/TTSServiceImplementation.ts
+++ b/src/TTSServiceImplementation.ts
@@ -43,9 +43,6 @@ export class TTSServiceImplementation implements TTSService {
 			content = content.replace(/\*/g, "");
 			content = content.replace(/\^/g, "");
 			content = content.replace(/==/g, "");
-
-			//block references
-			content = content.replace(/^\S{6}/g, "");
 		}
 		if (!this.plugin.settings.speakLinks) {
 			//regex from https://stackoverflow.com/a/37462442/5589264

--- a/src/TTSServiceImplementation.ts
+++ b/src/TTSServiceImplementation.ts
@@ -43,6 +43,9 @@ export class TTSServiceImplementation implements TTSService {
 			content = content.replace(/\*/g, "");
 			content = content.replace(/\^/g, "");
 			content = content.replace(/==/g, "");
+
+			//block references
+            content = content.replace(/\^\S*/g, "");
 		}
 		if (!this.plugin.settings.speakLinks) {
 			//regex from https://stackoverflow.com/a/37462442/5589264


### PR DESCRIPTION
fix: #2

I’ve taken out the line `content = content.replace(/^\S{6}/g, "");` from the code. I’m not certain about the original context in which it was used. My understanding is that this line eliminates the first six non-space characters of each line, potentially leading to the omission of some words during speech. If this modification leads to any issues, please let me know, and I will see how to fix this problem.